### PR TITLE
Fix HTMX parser request reuse bug

### DIFF
--- a/pkg/engine/parser/parser.go
+++ b/pkg/engine/parser/parser.go
@@ -609,36 +609,34 @@ func bodyMetaContentTagParser(resp *navigation.Response) (navigationRequests []*
 func bodyHtmxAttrParser(resp *navigation.Response) (navigationRequests []*navigation.Request) {
 	// exclude hx-delete
 	resp.Reader.Find("[hx-get],[hx-post],[hx-put],[hx-patch]").Each(func(i int, item *goquery.Selection) {
-		req := &navigation.Request{
-			RootHostname: resp.RootHostname,
-			Depth:        resp.Depth,
-			Source:       resp.Resp.Request.URL.String(),
-			Tag:          "htmx",
+		newRequest := func(method, attribute, value string) {
+			if value == "" {
+				return
+			}
+
+			req := &navigation.Request{
+				RootHostname: resp.RootHostname,
+				Depth:        resp.Depth,
+				Source:       resp.Resp.Request.URL.String(),
+				Tag:          "htmx",
+				Method:       method,
+				Attribute:    attribute,
+				URL:          resp.AbsoluteURL(value),
+			}
+			navigationRequests = append(navigationRequests, req)
 		}
 
 		if hxGet, ok := item.Attr("hx-get"); ok && hxGet != "" {
-			req.Method = http.MethodGet
-			req.URL = resp.AbsoluteURL(hxGet)
-			req.Attribute = "hx-get"
-			navigationRequests = append(navigationRequests, req)
+			newRequest(http.MethodGet, "hx-get", hxGet)
 		}
 		if hxPost, ok := item.Attr(("hx-post")); ok && hxPost != "" {
-			req.Method = http.MethodPost
-			req.URL = resp.AbsoluteURL(hxPost)
-			req.Attribute = "hx-post"
-			navigationRequests = append(navigationRequests, req)
+			newRequest(http.MethodPost, "hx-post", hxPost)
 		}
 		if hxPut, ok := item.Attr(("hx-put")); ok && hxPut != "" {
-			req.Method = http.MethodPut
-			req.URL = resp.AbsoluteURL(hxPut)
-			req.Attribute = "hx-put"
-			navigationRequests = append(navigationRequests, req)
+			newRequest(http.MethodPut, "hx-put", hxPut)
 		}
 		if hxPatch, ok := item.Attr(("hx-patch")); ok && hxPatch != "" {
-			req.Method = http.MethodPatch
-			req.URL = resp.AbsoluteURL(hxPatch)
-			req.Attribute = "hx-patch"
-			navigationRequests = append(navigationRequests, req)
+			newRequest(http.MethodPatch, "hx-patch", hxPatch)
 		}
 	})
 	return

--- a/pkg/engine/parser/parser_test.go
+++ b/pkg/engine/parser/parser_test.go
@@ -522,4 +522,16 @@ func TestHtmxBodyParser(t *testing.T) {
 		require.Equal(t, "https://htmx.org/account", navigationRequests[0].URL, "could not get correct url")
 		require.Equal(t, "PATCH", navigationRequests[0].Method, "could not get correct method")
 	})
+	t.Run("multiple attributes", func(t *testing.T) {
+		documentReader, _ := goquery.NewDocumentFromReader(strings.NewReader(`<div hx-get="/get" hx-post="/post"></div>`))
+		resp := &navigation.Response{Resp: &http.Response{Request: &http.Request{URL: parsed.URL}}, Reader: documentReader}
+		navigationRequests := bodyHtmxAttrParser(resp)
+		require.Len(t, navigationRequests, 2)
+
+		require.Equal(t, "https://htmx.org/get", navigationRequests[0].URL, "could not get correct url")
+		require.Equal(t, http.MethodGet, navigationRequests[0].Method, "could not get correct method")
+
+		require.Equal(t, "https://htmx.org/post", navigationRequests[1].URL, "could not get correct url")
+		require.Equal(t, http.MethodPost, navigationRequests[1].Method, "could not get correct method")
+	})
 }


### PR DESCRIPTION
## Summary
- ensure the HTMX attribute parser creates a fresh request structure for each attribute instead of reusing the same pointer
- add regression coverage verifying multiple HTMX attributes yield independent navigation requests

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68de7ffa398883339c559aff0fb1de53