### PR TITLE
Add tests for simple filter and queue strategy

### DIFF
--- a/pkg/utils/filters/filters_test.go
+++ b/pkg/utils/filters/filters_test.go
@@ -1,6 +1,8 @@
 package filters
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -16,4 +18,42 @@ func TestSimpleFilter(t *testing.T) {
 
 	unique = simple.UniqueURL("https://example.com")
 	require.False(t, unique, "could get unique value")
+}
+
+func TestSimpleFilterUniqueContent(t *testing.T) {
+	simple, err := NewSimple()
+	require.NoError(t, err, "could not create filter")
+	defer simple.Close()
+
+	payload := []byte("katana")
+
+	unique := simple.UniqueContent(payload)
+	require.True(t, unique, "expected new payload to be unique")
+
+	unique = simple.UniqueContent(payload)
+	require.False(t, unique, "expected duplicate payload to be rejected")
+}
+
+func TestSimpleFilterIsCycle(t *testing.T) {
+	simple := &Simple{}
+
+	t.Run("long url", func(t *testing.T) {
+		url := strings.Repeat("a", MaxChromeURLLength+1)
+		require.True(t, simple.IsCycle(url), "expected overly long url to be considered a cycle")
+	})
+
+	t.Run("repeating sequence", func(t *testing.T) {
+		var builder strings.Builder
+		base := "abcdefghijkl"
+		for i := 0; i < MaxSequenceCount; i++ {
+			builder.WriteString(base)
+			builder.WriteString(fmt.Sprintf("%02d", i))
+		}
+
+		require.True(t, simple.IsCycle(builder.String()), "expected highly repetitive sequence to be considered a cycle")
+	})
+
+	t.Run("valid url", func(t *testing.T) {
+		require.False(t, simple.IsCycle("https://example.com"), "expected typical url to not be a cycle")
+	})
 }

--- a/pkg/utils/queue/strategy_test.go
+++ b/pkg/utils/queue/strategy_test.go
@@ -1,0 +1,13 @@
+package queue
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStrategyString(t *testing.T) {
+	require.Equal(t, "breadth-first", BreadthFirst.String(), "expected breadth first string representation")
+	require.Equal(t, "depth-first", DepthFirst.String(), "expected depth first string representation")
+	require.Equal(t, "", Strategy(-1).String(), "expected unknown strategy to return empty string")
+}


### PR DESCRIPTION
## Summary
- add table-driven coverage for simple filter unique content and cycle detection
- add unit test for queue strategy String representations

## Testing
- go test ./pkg/utils/filters -count=1
- go test ./pkg/utils/queue -run TestStrategyString -count=1 -v

------
https://chatgpt.com/codex/tasks/task_e_68de800843508333892f63f2760d779f